### PR TITLE
Fix function definition for getSubscribedEvents()

### DIFF
--- a/src/InstallerPlugin.php
+++ b/src/InstallerPlugin.php
@@ -33,7 +33,7 @@ class InstallerPlugin implements PluginInterface, EventSubscriberInterface {
   /**
    * Get the event subscriber configuration for this plugin.
    */
-  public static function getSubscribedEvents(): array {
+  public static function getSubscribedEvents(){
     return [
       ScriptEvents::POST_INSTALL_CMD => 'onPostInstallCmd',
     ];


### PR DESCRIPTION
When trying to use fabalicious latest dev via composer, following error pops up,

```
composer install                                                                         
    1/1:	http://packagist.org/p/provider-latest$54c53ef45c2484f75a9ec96061d340448570638810d0f68c14866b55cae1eb73.json
    Finished: success: 1, skipped: 0, failure: 0, total: 1
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 104 installs, 0 updates, 0 removals
  - Installing factorial-io/fabalicious (dev-develop 3c887c2): Cloning 3c887c211a from cache
PHP Parse error:  syntax error, unexpected ':', expecting ';' or '{' in /Users/shibindas/work/multibasebox/multibasebox/projects/ssc_ild/vendor/factorial-io/fabalicious/src/InstallerPlugin.php on line 36

Parse error: syntax error, unexpected ':', expecting ';' or '{' in /Users/shibindas/work/multibasebox/multibasebox/projects/ssc_ild/vendor/factorial-io/fabalicious/src/InstallerPlugin.php on line 36
```


I think it was some bad typo or bad merge. The PR assumes it was a typo.