### PR TITLE
Feature/logger

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.3.1
+
+### new
+* new task `logLevel`: used to change the default logging level of the program.
+
+### changed
+
+* Refactored output logging to use python logging library.
+
 ## 2.3.0
 
 ### new
@@ -214,5 +223,3 @@
 * `needsComposer` is unsupported, set your `needs` accordingly.
 * the custom script-command `run_task` is not supported anymore. Use `execute(<task-name>)` instead.
 * the task `updateDrupalCore` is not ported over, not sure if it comes back.
-
-

--- a/docs/docs/available-tasks.md
+++ b/docs/docs/available-tasks.md
@@ -475,3 +475,18 @@ This docker-task will run a ssh-command to forward a local port to a port inside
 ### waitForServices
 
 This task will try to establish a ssh-connection into the docker-container and if the connection succeeds, waits for `supervisorctl status` to return success. This is useful in scripts to wait for any services that need some time to start up. Obviously this task depends on `supervisorctl`.
+
+### logLevel
+
+Can be used to override default logging level used by fabalicious.
+Available values :
+
+- DEBUG
+- INFO
+- WARNING
+- ERROR
+- CRITICAL
+
+**Examples**
+
+* `fab logLevel:DEBUG config:mbb ssh` will start outputting DEBUG level messages.

--- a/fabfile.py
+++ b/fabfile.py
@@ -63,7 +63,7 @@ def blueprint(branch, configName=False, output=False):
   template = blueprints.getTemplate(configName)
   if not template:
     log.error('No blueprint found in configuration for key %s!' % configName)
-    log.warning('run via fab blueprint=<identifier>,configName=<configName>,output=<bool>')
+    log.info('run via fab blueprint=<identifier>,configName=<configName>,output=<bool>')
     exit(1)
 
   c = blueprints.apply(branch, template)
@@ -470,7 +470,7 @@ def createDestroyHelper(stages, command, **kwargs):
 
   for step in stages:
     step['dockerConfig'] = dockerConfig
-    log.warning(command + ': current stage: \'{stage}\' via \'{connection}\''.format(**step))
+    log.info(command + ': current stage: \'{stage}\' via \'{connection}\''.format(**step))
 
     hostConfig = {}
     for key in ['host', 'user', 'port']:

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import logging
+log = logging.getLogger('fabric.fabalicious')
+
 from fabric.api import *
 from fabric.network import *
 from fabric.context_managers import settings as _settings
@@ -18,40 +21,15 @@ sys.path.append(root_folder)
 from lib import methods
 from lib import configuration
 from lib import blueprints
+from lib import utils
 
-
-import logging
-
-# Try to use same logging level as fabric does.
-LOG_LEVEL = logging.INFO
-for arg in sys.argv:
-  if arg == "--show=debug":
-    LOG_LEVEL = logging.DEBUG
-
-logging.root.setLevel(LOG_LEVEL)
-
-from lib import colorize
-stream = colorize.ColorizingStreamHandler()
-stream.setLevel(LOG_LEVEL)
-
-# Default logger.
-log = logging.getLogger('fabric.fabalicious')
-log.setLevel(LOG_LEVEL)
-log.addHandler(stream)
-
-# Configure yapsy logger.
-yapsylog = logging.getLogger('yapsy')
-yapsylog.setLevel(LOG_LEVEL)
-yapsylog.addHandler(stream)
-
-# Configure paramiko logger.
-paramikolog = logging.getLogger('paramiko')
-paramikolog.setLevel(LOG_LEVEL)
-paramikolog.addHandler(stream)
-
+utils.setup_logging(root_folder)
 
 configuration.fabfile_basedir = root_folder
 
+@task
+def log_level(level=None):
+    return level
 
 @task
 def config(configName='local'):

--- a/fabfile.py
+++ b/fabfile.py
@@ -23,13 +23,13 @@ from lib import configuration
 from lib import blueprints
 from lib import utils
 
-utils.setup_logging(root_folder)
+utils.setup_global_logging(root_folder)
 
 configuration.fabfile_basedir = root_folder
 
 @task
 def logLevel(level=None):
-    return level
+    utils.setup_logging(root_folder, log_level = level)
 
 @task
 def config(configName='local'):

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,28 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import logging
-LOG_LEVEL = logging.DEBUG
-try:
-  LOGFORMAT = "  %(log_color)s%(levelname)-8s%(reset)s | %(log_color)s%(message)s%(reset)s"
-  from colorlog import ColoredFormatter
-  logging.root.setLevel(LOG_LEVEL)
-  formatter = ColoredFormatter(LOGFORMAT)
-  stream = logging.StreamHandler()
-  stream.setLevel(LOG_LEVEL)
-  stream.setFormatter(formatter)
-  log = logging.getLogger('fabric.fabalicious')
-  log.setLevel(LOG_LEVEL)
-  log.addHandler(stream)
-except:
-  logging.root.setLevel(LOG_LEVEL)
-  stream = logging.StreamHandler()
-  stream.setLevel(LOG_LEVEL)
-  log = logging.getLogger('fabric.fabalicious')
-  log.setLevel(LOG_LEVEL)
-  log.addHandler(stream)
-  pass
-
 from fabric.api import *
 from fabric.network import *
 from fabric.context_managers import settings as _settings
@@ -40,6 +18,18 @@ sys.path.append(root_folder)
 from lib import methods
 from lib import configuration
 from lib import blueprints
+
+
+import logging
+LOG_LEVEL = logging.DEBUG
+logging.root.setLevel(LOG_LEVEL)
+from lib import colorize
+stream = colorize.ColorizingStreamHandler()
+stream.setLevel(LOG_LEVEL)
+log = logging.getLogger('fabric.fabalicious')
+log.setLevel(LOG_LEVEL)
+log.addHandler(stream)
+
 
 configuration.fabfile_basedir = root_folder
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,11 +1,34 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import logging
+LOG_LEVEL = logging.DEBUG
+try:
+  LOGFORMAT = "  %(log_color)s%(levelname)-8s%(reset)s | %(log_color)s%(message)s%(reset)s"
+  from colorlog import ColoredFormatter
+  logging.root.setLevel(LOG_LEVEL)
+  formatter = ColoredFormatter(LOGFORMAT)
+  stream = logging.StreamHandler()
+  stream.setLevel(LOG_LEVEL)
+  stream.setFormatter(formatter)
+  log = logging.getLogger('fabalicious')
+  log.setLevel(LOG_LEVEL)
+  log.addHandler(stream)
+except:
+  logging.root.setLevel(LOG_LEVEL)
+  stream = logging.StreamHandler()
+  stream.setLevel(LOG_LEVEL)
+  log = logging.getLogger('fabalicious')
+  log.setLevel(LOG_LEVEL)
+  log.addHandler(stream)
+  pass
+
 from fabric.api import *
 from fabric.colors import green, red, yellow
 from fabric.network import *
 from fabric.context_managers import settings as _settings
 from fabric.state import output
+
 import os.path
 import time
 import datetime
@@ -31,8 +54,8 @@ def config(configName='local'):
 def blueprint(branch, configName=False, output=False):
   template = blueprints.getTemplate(configName)
   if not template:
-    print red('No blueprint found in configuration for key %s!' % configName)
-    print yellow('run via fab blueprint=<identifier>,configName=<configName>,output=<bool>')
+    log.error('No blueprint found in configuration for key %s!' % configName)
+    log.warning('run via fab blueprint=<identifier>,configName=<configName>,output=<bool>')
     exit(1)
 
   c = blueprints.apply(branch, template)
@@ -52,7 +75,7 @@ def getProperty(in_key):
       if key in c:
         c = c[key]
       else:
-        print red('property "%s" not found!' % in_key)
+        log.error('property "%s" not found!' % in_key)
         exit(1)
 
   print c
@@ -92,13 +115,13 @@ def about(config_name=False):
 
 @task
 def info():
-  print green('Fabalicious %s by Factorial.io. MIT Licensed.\n\n' % configuration.fabalicious_version)
+  log.info('Fabalicious %s by Factorial.io. MIT Licensed.\n\n' % configuration.fabalicious_version)
 
 @task
 def version():
   configuration.check('git')
   version = methods.call('git', 'getVersion', configuration.current())
-  print green('%s @ %s tagged with: %s' % (configuration.getSettings('name'), configuration.current('config_name'), version))
+  log.info('%s @ %s tagged with: %s' % (configuration.getSettings('name'), configuration.current('config_name'), version))
 
 @task
 def drush(drush_command):
@@ -119,7 +142,7 @@ def composer(composer_command):
 @task
 def list():
   config = configuration.getAll()
-  print('Found configurations for "%s":' % config['name']+"\n")
+  log.info('Found configurations for "%s":' % config['name']+"\n")
   keys = config['hosts']
   keys = sorted(keys)
   for key in keys:
@@ -149,7 +172,7 @@ def sshCommand():
 def putFile(fileName):
   configuration.check()
   if configuration.current()['runLocally']:
-    print red("putFile not supported when 'runLocally' is set!")
+    log.error("putFile not supported when 'runLocally' is set!")
     exit(1)
 
   methods.call('files', 'put', configuration.current(), filename=fileName)
@@ -166,7 +189,7 @@ def getSQLDump():
 
   file_name = '--'.join([configuration.current('config_name'), time.strftime("%Y%m%d-%H%M%S")]) + '.sql'
 
-  print green('Get SQL dump from %s' % configuration.current('config_name'))
+  log.info('Get SQL dump from %s' % configuration.current('config_name'))
 
   file_name = '/tmp/' + file_name
   methods.runTask(configuration.current(), 'backupSql', backup_file_name = file_name)
@@ -183,7 +206,7 @@ def getFilesDump():
   configuration.check();
   file_name = '--'.join([configuration.current('config_name'), time.strftime("%Y%m%d-%H%M%S")]) + '.tgz'
 
-  print green('Get files dump from %s' % configuration.current('config_name'))
+  log.info('Get files dump from %s' % configuration.current('config_name'))
 
   file_name = '/tmp/' + file_name
   methods.runTask(configuration.current(), 'backupFiles', backup_file_name = file_name)
@@ -196,7 +219,7 @@ def getFilesDump():
 @task
 def backup(withFiles = True):
   configuration.check()
-  print green('backing up files and database of "%s" @ "%s"' % (configuration.getSettings('name'), configuration.current('config_name')))
+  log.info('backing up files and database of "%s" @ "%s"' % (configuration.getSettings('name'), configuration.current('config_name')))
   i = datetime.datetime.now()
   basename = [
     configuration.current('config_name'),
@@ -247,7 +270,7 @@ def get_backup_files(commit):
         hash = result['hash']
 
   if not hash:
-    print red('Coud not find requested backup: %s' % commit)
+    log.error('Coud not find requested backup: %s' % commit)
     listBackups()
     exit()
   else:
@@ -282,7 +305,7 @@ def script(scriptKey = False, *args, **kwargs):
     scriptData = scripts[scriptKey] if scriptKey in scripts else False
 
   if not scriptData:
-    print red('Could not find any script named "%s" in fabfile.yaml' % scriptKey)
+    log.error('Could not find any script named "%s" in fabfile.yaml' % scriptKey)
     if configuration.current('scripts'):
       print 'Available scripts in %s:\n  - ' % configuration.current('config_name') + '\n  - '.join(configuration.current('scripts').keys())
 
@@ -362,7 +385,7 @@ def install(**kwargs):
   configuration.check()
   config = configuration.current()
   if config['type'] == 'prod' or not config['supportsInstalls']:
-    print red('Task install is not supported for this configuration. Please check if "type" and "supportsInstalls" is set correctly.')
+    log.error('Task install is not supported for this configuration. Please check if "type" and "supportsInstalls" is set correctly.')
     exit(1)
 
   if 'nextTasks' not in kwargs:
@@ -381,10 +404,10 @@ def installFrom(source_config_name, **kwargs):
 def createApp(**kwargs):
   configuration.check(['docker'])
   if not configuration.getSettings('repository'):
-    print red('Missing repository in fabfile, can\'t continue')
+    log.error('Missing repository in fabfile, can\'t continue')
     exit(1)
 
-  print green('Create app from source at %s' % configuration.getSettings('repository'))
+  log.info('Create app from source at %s' % configuration.getSettings('repository'))
   stages = [
     {
       'stage': 'checkExistingInstallation',
@@ -396,7 +419,7 @@ def createApp(**kwargs):
   ]
   createDestroyHelper(stages, 'createApp')
   if stages[0]['context']['installationExists']:
-    print green('Found an existing installation, running deploy instead!')
+    log.info('Found an existing installation, running deploy instead!')
 
     # Spin up the container.
     stages = [
@@ -439,7 +462,7 @@ def createDestroyHelper(stages, command, **kwargs):
 
   for step in stages:
     step['dockerConfig'] = dockerConfig
-    print yellow(command + ': current stage: \'{stage}\' via \'{connection}\''.format(**step))
+    log.warning(command + ': current stage: \'{stage}\' via \'{connection}\''.format(**step))
 
     hostConfig = {}
     for key in ['host', 'user', 'port']:
@@ -456,7 +479,7 @@ def updateApp(**kwargs):
   configuration.check()
   config = configuration.current()
   if config['type'] != 'dev':
-    print red('Task updateApp is not supported for this configuration. Please check if "type" is set correctly.')
+    log.error('Task updateApp is not supported for this configuration. Please check if "type" is set correctly.')
     exit(1)
   backupDB()
   methods.runTask(configuration.current(), 'updateApp', **kwargs)

--- a/fabfile.py
+++ b/fabfile.py
@@ -28,7 +28,7 @@ utils.setup_logging(root_folder)
 configuration.fabfile_basedir = root_folder
 
 @task
-def log_level(level=None):
+def logLevel(level=None):
     return level
 
 @task

--- a/fabfile.py
+++ b/fabfile.py
@@ -22,16 +22,29 @@ from lib import blueprints
 
 import logging
 
+# Try to use same logging level as fabric does.
 LOG_LEVEL = logging.INFO
+for arg in sys.argv:
+  if arg == "--show=debug":
+    LOG_LEVEL = logging.DEBUG
+
 logging.root.setLevel(LOG_LEVEL)
+
 from lib import colorize
 stream = colorize.ColorizingStreamHandler()
 stream.setLevel(LOG_LEVEL)
+
+# Default logger.
 log = logging.getLogger('fabric.fabalicious')
 log.setLevel(LOG_LEVEL)
 log.addHandler(stream)
 
-# Initialize paramiko logging.
+# Configure yapsy logger.
+yapsylog = logging.getLogger('yapsy')
+yapsylog.setLevel(LOG_LEVEL)
+yapsylog.addHandler(stream)
+
+# Configure paramiko logger.
 paramikolog = logging.getLogger('paramiko')
 paramikolog.setLevel(LOG_LEVEL)
 paramikolog.addHandler(stream)

--- a/fabfile.py
+++ b/fabfile.py
@@ -11,14 +11,14 @@ try:
   stream = logging.StreamHandler()
   stream.setLevel(LOG_LEVEL)
   stream.setFormatter(formatter)
-  log = logging.getLogger('fabalicious')
+  log = logging.getLogger('fabric.fabalicious')
   log.setLevel(LOG_LEVEL)
   log.addHandler(stream)
 except:
   logging.root.setLevel(LOG_LEVEL)
   stream = logging.StreamHandler()
   stream.setLevel(LOG_LEVEL)
-  log = logging.getLogger('fabalicious')
+  log = logging.getLogger('fabric.fabalicious')
   log.setLevel(LOG_LEVEL)
   log.addHandler(stream)
   pass

--- a/fabfile.py
+++ b/fabfile.py
@@ -30,6 +30,11 @@ log = logging.getLogger('fabric.fabalicious')
 log.setLevel(LOG_LEVEL)
 log.addHandler(stream)
 
+# Initialize paramiko logging.
+paramikolog = logging.getLogger('paramiko')
+paramikolog.setLevel(LOG_LEVEL)
+paramikolog.addHandler(stream)
+
 
 configuration.fabfile_basedir = root_folder
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -24,7 +24,6 @@ except:
   pass
 
 from fabric.api import *
-from fabric.colors import green, red, yellow
 from fabric.network import *
 from fabric.context_managers import settings as _settings
 from fabric.state import output

--- a/fabfile.py
+++ b/fabfile.py
@@ -21,7 +21,8 @@ from lib import blueprints
 
 
 import logging
-LOG_LEVEL = logging.DEBUG
+
+LOG_LEVEL = logging.INFO
 logging.root.setLevel(LOG_LEVEL)
 from lib import colorize
 stream = colorize.ColorizingStreamHandler()

--- a/lib/blueprints/__init__.py
+++ b/lib/blueprints/__init__.py
@@ -1,5 +1,5 @@
 import logging
-log = logging.getLogger('fabalicious.blueprints')
+log = logging.getLogger('fabric.fabalicious.blueprints')
 
 import yaml
 import re

--- a/lib/blueprints/__init__.py
+++ b/lib/blueprints/__init__.py
@@ -3,7 +3,6 @@ log = logging.getLogger('fabalicious.blueprints')
 
 import yaml
 import re
-from fabric.colors import green, red, yellow
 from lib import configuration
 
 def getTemplate(configName):

--- a/lib/blueprints/__init__.py
+++ b/lib/blueprints/__init__.py
@@ -1,8 +1,10 @@
+import logging
+log = logging.getLogger('fabalicious.blueprints')
+
 import yaml
 import re
 from fabric.colors import green, red, yellow
 from lib import configuration
-
 
 def getTemplate(configName):
   settings = configuration.get_all_configurations()
@@ -57,7 +59,7 @@ def apply_helper(value, replacements):
 
     p2 = re.compile('\%(\S*)\%')
     if p2.search(result):
-      print red('Found replacement pattern in "%s"' % result)
+      log.error('Found replacement pattern in "%s"' % result)
       print "Available replacement patterns:"
       for key, val in replacements.items():
         print '- ' + key
@@ -92,4 +94,3 @@ def apply(identifier, template):
 def output(config):
   data = { 'hosts': { config['configName']: config } }
   print yaml.dump(data, default_flow_style=False, default_style='')
-

--- a/lib/colorize.py
+++ b/lib/colorize.py
@@ -1,0 +1,194 @@
+#
+# Copyright (C) 2010-2017 Vinay Sajip. All rights reserved.
+#
+import ctypes
+import logging
+import os
+
+try:
+    unicode
+except NameError:
+    unicode = None
+
+class ColorizingStreamHandler(logging.StreamHandler):
+    """
+    A stream handler which supports colorizing of console streams
+    under Windows, Linux and Mac OS X.
+
+    :param strm: The stream to colorize - typically ``sys.stdout``
+                 or ``sys.stderr``.
+    """
+
+    # color names to indices
+    color_map = {
+        'black': 0,
+        'red': 1,
+        'green': 2,
+        'yellow': 3,
+        'blue': 4,
+        'magenta': 5,
+        'cyan': 6,
+        'white': 7,
+    }
+
+    #levels to (background, foreground, bold/intense)
+    if os.name == 'nt':
+        level_map = {
+            logging.DEBUG: (None, 'blue', True),
+            logging.INFO: (None, 'white', False),
+            logging.WARNING: (None, 'yellow', True),
+            logging.ERROR: (None, 'red', True),
+            logging.CRITICAL: ('red', 'white', True),
+        }
+    else:
+        "Maps levels to colour/intensity settings."
+        level_map = {
+            logging.DEBUG: (None, 'blue', False),
+            logging.INFO: (None, 'black', False),
+            logging.WARNING: (None, 'yellow', False),
+            logging.ERROR: (None, 'red', False),
+            logging.CRITICAL: ('red', 'white', True),
+        }
+
+    csi = '\x1b['
+    reset = '\x1b[0m'
+
+    @property
+    def is_tty(self):
+        "Returns true if the handler's stream is a terminal."
+        isatty = getattr(self.stream, 'isatty', None)
+        return isatty and isatty()
+
+    def emit(self, record):
+        try:
+            message = self.format(record)
+            stream = self.stream
+            if unicode and isinstance(message, unicode):
+                # Sometimes there's an encoding attribute, but it's None.
+                enc = getattr(stream, 'encoding', None) or 'utf-8'
+                message = message.encode(enc, 'replace')
+            if not self.is_tty:
+                stream.write(message)
+            else:
+                self.output_colorized(message)
+            stream.write(getattr(self, 'terminator', '\n'))
+            self.flush()
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except:
+            self.handleError(record)
+
+    if os.name != 'nt':
+        def output_colorized(self, message):
+            """
+            Output a colorized message.
+
+            On Linux and Mac OS X, this method just writes the
+            already-colorized message to the stream, since on these
+            platforms console streams accept ANSI escape sequences
+            for colorization. On Windows, this handler implements a
+            subset of ANSI escape sequence handling by parsing the
+            message, extracting the sequences and making Win32 API
+            calls to colorize the output.
+
+            :param message: The message to colorize and output.
+            """
+            self.stream.write(message)
+    else:
+        import re
+        ansi_esc = re.compile(r'\x1b\[((?:\d+)(?:;(?:\d+))*)m')
+
+        nt_color_map = {
+            0: 0x00,    # black
+            1: 0x04,    # red
+            2: 0x02,    # green
+            3: 0x06,    # yellow
+            4: 0x01,    # blue
+            5: 0x05,    # magenta
+            6: 0x03,    # cyan
+            7: 0x07,    # white
+        }
+
+        def output_colorized(self, message):
+            """
+            Output a colorized message.
+
+            On Linux and Mac OS X, this method just writes the
+            already-colorized message to the stream, since on these
+            platforms console streams accept ANSI escape sequences
+            for colorization. On Windows, this handler implements a
+            subset of ANSI escape sequence handling by parsing the
+            message, extracting the sequences and making Win32 API
+            calls to colorize the output.
+
+            :param message: The message to colorize and output.
+            """
+            parts = self.ansi_esc.split(message)
+            write = self.stream.write
+            h = None
+            fd = getattr(self.stream, 'fileno', None)
+            if fd is not None:
+                fd = fd()
+                if fd in (1, 2): # stdout or stderr
+                    h = ctypes.windll.kernel32.GetStdHandle(-10 - fd)
+            while parts:
+                text = parts.pop(0)
+                if text:
+                    write(text)
+                if parts:
+                    params = parts.pop(0)
+                    if h is not None:
+                        params = [int(p) for p in params.split(';')]
+                        color = 0
+                        for p in params:
+                            if 40 <= p <= 47:
+                                color |= self.nt_color_map[p - 40] << 4
+                            elif 30 <= p <= 37:
+                                color |= self.nt_color_map[p - 30]
+                            elif p == 1:
+                                color |= 0x08 # foreground intensity on
+                            elif p == 0: # reset to default color
+                                color = 0x07
+                            else:
+                                pass # error condition ignored
+                        ctypes.windll.kernel32.SetConsoleTextAttribute(h, color)
+
+    def colorize(self, message, record):
+        """
+        Colorize a message for a logging event.
+
+        This implementation uses the ``level_map`` class attribute to
+        map the LogRecord's level to a colour/intensity setting, which is
+        then applied to the whole message.
+
+        :param message: The message to colorize.
+        :param record: The ``LogRecord`` for the message.
+        """
+        if record.levelno in self.level_map:
+            bg, fg, bold = self.level_map[record.levelno]
+            params = []
+            if bg in self.color_map:
+                params.append(str(self.color_map[bg] + 40))
+            if fg in self.color_map:
+                params.append(str(self.color_map[fg] + 30))
+            if bold:
+                params.append('1')
+            if params:
+                message = ''.join((self.csi, ';'.join(params),
+                                   'm', message, self.reset))
+        return message
+
+    def format(self, record):
+        """
+        Formats a record for output.
+
+        This implementation colorizes the message line, but leaves
+        any traceback unolorized.
+        """
+        message = logging.StreamHandler.format(self, record)
+        if self.is_tty:
+            # Don't colorize any traceback
+            parts = message.split('\n', 1)
+            parts[0] = self.colorize(parts[0], record)
+            message = '\n'.join(parts)
+        return message

--- a/lib/colorize.py
+++ b/lib/colorize.py
@@ -44,7 +44,7 @@ class ColorizingStreamHandler(logging.StreamHandler):
         "Maps levels to colour/intensity settings."
         level_map = {
             logging.DEBUG: (None, 'blue', False),
-            logging.INFO: (None, 'black', False),
+            logging.INFO: (None, 'green', False),
             logging.WARNING: (None, 'yellow', False),
             logging.ERROR: (None, 'red', False),
             logging.CRITICAL: ('red', 'white', True),

--- a/lib/colorize.py
+++ b/lib/colorize.py
@@ -44,8 +44,8 @@ class ColorizingStreamHandler(logging.StreamHandler):
         "Maps levels to colour/intensity settings."
         level_map = {
             logging.DEBUG: (None, 'blue', False),
-            logging.INFO: (None, 'green', False),
-            logging.WARNING: (None, 'yellow', False),
+            logging.INFO: (None, 'yellow', False),
+            logging.WARNING: ('yellow', 'black', False),
             logging.ERROR: (None, 'red', False),
             logging.CRITICAL: ('red', 'white', True),
         }

--- a/lib/configuration/__init__.py
+++ b/lib/configuration/__init__.py
@@ -283,7 +283,7 @@ def get_configuration(name):
 
     return host_config
 
-  print(red('Configuraton '+name+' not found \n'))
+  log.error('Configuraton '+name+' not found \n')
   list()
   exit(1)
 
@@ -421,7 +421,7 @@ def check(methods= False):
     else:
       return True
 
-  print(red('no config set! Please use fab config:<your-config> <task>'))
+  log.error('no config set! Please use fab config:<your-config> <task>')
   exit(1)
 
 

--- a/lib/configuration/__init__.py
+++ b/lib/configuration/__init__.py
@@ -1,5 +1,5 @@
 import logging
-log = logging.getLogger('fabalicious.configuration')
+log = logging.getLogger('fabric.fabalicious.configuration')
 
 from fabric.api import *
 from fabric.state import output, env

--- a/lib/configuration/__init__.py
+++ b/lib/configuration/__init__.py
@@ -368,7 +368,7 @@ def get_configuration_via_http_impl(config_file_name, as_yaml = True):
     data = remote_config_cache_load(config_file_name, as_yaml)
     if data:
       if offline:
-        log.warning('Using cached configuration for %s' % config_file_name)
+        log.info('Using cached configuration for %s' % config_file_name)
       else:
         log.warning('Could not read configuration from %s, using cached data.' % config_file_name)
 

--- a/lib/configuration/__init__.py
+++ b/lib/configuration/__init__.py
@@ -3,7 +3,6 @@ log = logging.getLogger('fabalicious.configuration')
 
 from fabric.api import *
 from fabric.state import output, env
-from fabric.colors import green, red, yellow
 import os.path
 import urllib2
 import yaml

--- a/lib/configuration/__init__.py
+++ b/lib/configuration/__init__.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger('fabalicious.configuration')
+
 from fabric.api import *
 from fabric.state import output, env
 from fabric.colors import green, red, yellow
@@ -36,8 +39,8 @@ def load_all_yamls_from_dir(path):
       result[key] = data
 
     except IOError as e:
-      print red('Could not read from %s' % file)
-      print red(e)
+      log.error('Could not read from %s' % file)
+      log.error(e)
   return result
 
 
@@ -64,7 +67,7 @@ def load_configuration(input_file):
 
   override_filename = find_configfiles(['fabfile.local.yaml'], 3)
   if override_filename:
-    print yellow('Using overrides from %s' % override_filename)
+    log.warning('Using overrides from %s' % override_filename)
     override_data = yaml.load(open(override_filename, 'r'))
     data = data_merge(data, override_data)
 
@@ -84,7 +87,7 @@ def get_all_configurations():
     except IOError:
       print "could not read from %s " % (config_file_name)
   else:
-    print red('could not find suitable configuration file!')
+    log.error('could not find suitable configuration file!')
 
   exit(1)
 
@@ -172,8 +175,8 @@ def check_fabalicious_version(required_version, msg):
   current_version = fabalicious_version
 
   if (versiontuple(current_version) < versiontuple(required_version)):
-    print red('The %s needs %s as minimum app-version.' % (msg, required_version))
-    print red('You are currently using %s. Please update your fabalicious installation.' % current_version)
+    log.error('The %s needs %s as minimum app-version.' % (msg, required_version))
+    log.error('You are currently using %s. Please update your fabalicious installation.' % current_version)
     exit(1)
 
 def validate_config_against_methods(config):
@@ -188,7 +191,7 @@ def validate_config_against_methods(config):
 
   if len(errors) > 0:
     for key, msg in errors.iteritems():
-      print red('Key \'%s\' in %s: %s' % (key, config['config_name'], msg))
+      log.error('Key \'%s\' in %s: %s' % (key, config['config_name'], msg))
 
     exit(1)
 
@@ -276,7 +279,7 @@ def get_configuration(name):
 
     for key in unsupported:
       if key in host_config:
-        print red(unsupported[key] % key)
+        log.error(unsupported[key] % key)
 
     return host_config
 
@@ -297,9 +300,9 @@ def get_configuration_via_file(config_file_name):
       break;
 
   if not found:
-    print red("could not find configuration %s" % config_file_name)
+    log.error("could not find configuration %s" % config_file_name)
     for candidate in candidates:
-      print red("- tried: %s" % candidate)
+      log.error("- tried: %s" % candidate)
 
     return False
 
@@ -309,7 +312,7 @@ def get_configuration_via_file(config_file_name):
     stream = open(found, 'r')
     data = yaml.load(stream)
   except IOError:
-    print red("could not read configuration from %s" % found)
+    log.error("could not read configuration from %s" % found)
 
   return data
 
@@ -366,13 +369,13 @@ def get_configuration_via_http_impl(config_file_name, as_yaml = True):
     data = remote_config_cache_load(config_file_name, as_yaml)
     if data:
       if offline:
-        print yellow('Using cached configuration for %s' % config_file_name)
+        log.warning('Using cached configuration for %s' % config_file_name)
       else:
-        print yellow('Could not read configuration from %s, using cached data.' % config_file_name)
+        log.warning('Could not read configuration from %s, using cached data.' % config_file_name)
 
       return data
 
-    print red('Could not read/find configuration from %s' % config_file_name)
+    log.error('Could not read/find configuration from %s' % config_file_name)
 
   return False
 
@@ -412,7 +415,7 @@ def check(methods= False):
         if method in env.config['needs']:
           found = True
       if not found:
-          print red('Config "%s" does not support method "%s"' % (env.config['config_name'], ', '.join(methods)))
+          log.error('Config "%s" does not support method "%s"' % (env.config['config_name'], ', '.join(methods)))
           exit(1)
       return True
     else:
@@ -544,7 +547,7 @@ def getDockerConfig(docker_config_name, runLocally = False, printErrors=True):
   if len(errors) > 0:
     if printErrors:
       for key in errors:
-        print red('Missing key \'%s\' in docker-configuration %s' % (key, docker_config_name))
+        log.error('Missing key \'%s\' in docker-configuration %s' % (key, docker_config_name))
 
     return False
 

--- a/lib/methods/__init__.py
+++ b/lib/methods/__init__.py
@@ -2,10 +2,6 @@ import logging
 log = logging.getLogger('fabalicious.methods')
 
 import inspect, sys
-from fabric.colors import green, yellow
-
-import logging
-log = logging.getLogger('fabalicious.methods')
 
 from types import TypeType
 from base import BaseMethod

--- a/lib/methods/__init__.py
+++ b/lib/methods/__init__.py
@@ -1,5 +1,11 @@
+import logging
+log = logging.getLogger('fabalicious.methods')
+
 import inspect, sys
 from fabric.colors import green, yellow
+
+import logging
+log = logging.getLogger('fabalicious.methods')
 
 from types import TypeType
 from base import BaseMethod
@@ -103,7 +109,7 @@ def runTaskImpl(methodNames, taskName, configuration, fallback_allowed, **kwargs
   fn_called = False
   for methodName in methodNames:
     if not 'quiet' in kwargs and not msg_printed:
-      print yellow('Running task %s on configuration %s' % (taskName, configuration['config_name']))
+      log.warning('Running task %s on configuration %s' % (taskName, configuration['config_name']))
       msg_printed = True
     fn = get(methodName, taskName)
     if fn:

--- a/lib/methods/__init__.py
+++ b/lib/methods/__init__.py
@@ -105,7 +105,7 @@ def runTaskImpl(methodNames, taskName, configuration, fallback_allowed, **kwargs
   fn_called = False
   for methodName in methodNames:
     if not 'quiet' in kwargs and not msg_printed:
-      log.warning('Running task %s on configuration %s' % (taskName, configuration['config_name']))
+      log.info('Running task %s on configuration %s' % (taskName, configuration['config_name']))
       msg_printed = True
     fn = get(methodName, taskName)
     if fn:

--- a/lib/methods/__init__.py
+++ b/lib/methods/__init__.py
@@ -1,5 +1,5 @@
 import logging
-log = logging.getLogger('fabalicious.methods')
+log = logging.getLogger('fabric.fabalicious.methods')
 
 import inspect, sys
 

--- a/lib/methods/base.py
+++ b/lib/methods/base.py
@@ -3,7 +3,6 @@ log = logging.getLogger('fabalicious.base')
 
 from fabric.api import *
 from fabric.state import output, env
-from fabric.colors import green, red
 from fabric.context_managers import env
 from fabric.network import *
 from fabric.contrib.files import exists

--- a/lib/methods/base.py
+++ b/lib/methods/base.py
@@ -1,5 +1,5 @@
 import logging
-log = logging.getLogger('fabalicious.base')
+log = logging.getLogger('fabric.fabalicious.base')
 
 from fabric.api import *
 from fabric.state import output, env

--- a/lib/methods/base.py
+++ b/lib/methods/base.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger('fabalicious.base')
+
 from fabric.api import *
 from fabric.state import output, env
 from fabric.colors import green, red
@@ -159,7 +162,7 @@ class BaseMethod(object):
 
 
   def cd(self, path):
-    # print red('cd: %d %s'% (self.run_locally,  path))
+    # log.error('cd: %d %s'% (self.run_locally,  path))
     return lcd(path) if self.run_locally else cd(path)
 
   def expandCommand(self, in_cmd):
@@ -177,7 +180,7 @@ class BaseMethod(object):
     return cmd
 
   def run(self, cmd, **kwargs):
-    # print red("run: %d %s" % ( self.run_locally, cmd))
+    # log.error("run: %d %s" % ( self.run_locally, cmd))
     cmd = self.expandCommand(cmd)
 
     if self.run_locally:
@@ -210,12 +213,12 @@ class BaseMethod(object):
         result = self.run(cmd)
 
         if not may_fail and result.return_code != 0:
-          print red('%s failed:' %s)
+          log.error('%s failed:' %s)
           print result
 
         return result
       except:
-        print red('%s failed' % cmd)
+        log.error('%s failed' % cmd)
 
         if output['aborts']:
           raise SystemExit('%s failed' % cmd);

--- a/lib/methods/composer.py
+++ b/lib/methods/composer.py
@@ -1,5 +1,5 @@
 import logging
-log = logging.getLogger('fabalicious.composer')
+log = logging.getLogger('fabric.fabalicious.composer')
 
 from base import BaseMethod
 from fabric.api import *

--- a/lib/methods/composer.py
+++ b/lib/methods/composer.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger('fabalicious.composer')
+
 from base import BaseMethod
 from fabric.api import *
 
@@ -48,4 +51,3 @@ class ComposerMethod(BaseMethod):
       targetPath = config['gitRootFolder']
       with self.cd(targetPath):
         self.run('#!composer install %s' % self.getArgs(config))
-

--- a/lib/methods/docker.py
+++ b/lib/methods/docker.py
@@ -6,7 +6,6 @@ from fabric.api import *
 from fabric.network import *
 from fabric.context_managers import settings as _settings
 from fabric.context_managers import env
-from fabric.colors import green, red
 from lib import configuration
 import copy
 from lib.utils import validate_dict

--- a/lib/methods/docker.py
+++ b/lib/methods/docker.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger('fabalicious.docker')
+
 from base import BaseMethod
 from fabric.api import *
 from fabric.network import *
@@ -74,7 +77,7 @@ class DockerMethod(BaseMethod):
         output = run('docker inspect --format "{{ .NetworkSettings.IPAddress }}" %s ' % (docker_name))
 
     except SystemExit:
-      print red('Docker not running, can\'t get ip')
+      log.error('Docker not running, can\'t get ip')
       return False
 
     ip_address = output.stdout.strip()
@@ -98,19 +101,19 @@ class DockerMethod(BaseMethod):
   def startRemoteAccess(self, config, port="80", publicPort="8888", **kwargs):
     docker_config = self.getDockerConfig(config)
     if not docker_config:
-      print red('No docker configuration found!')
+      log.error('No docker configuration found!')
       exit(1)
 
     ip = self.getIpAddress(config)
 
     if not ip:
-      print red('Could not get docker-ip-address of docker-container %s.' % config['docker']['name'])
+      log.error('Could not get docker-ip-address of docker-container %s.' % config['docker']['name'])
       exit(1)
 
     public_ip = '0.0.0.0'
     if 'ip' in kwargs:
       public_ip = kwargs['ip']
-    print green("I am about to start the port forwarding via SSH. If you are finished, just type exit after the prompt.")
+    log.info("I am about to start the port forwarding via SSH. If you are finished, just type exit after the prompt.")
     local("ssh -L%s:%s:%s:%s -p %s %s@%s" % (public_ip, publicPort, ip, port, docker_config['port'], docker_config['user'], docker_config['host']))
     exit(0)
 
@@ -157,7 +160,7 @@ class DockerMethod(BaseMethod):
           full_file_name = configuration.getBaseDir() + '/' + value
 
         if not os.path.exists(full_file_name):
-          print red('Could not copy file to container, missing file: %s' % full_file_name)
+          log.error('Could not copy file to container, missing file: %s' % full_file_name)
           preflight_succeeded = False
         else:
           files[key] = full_file_name
@@ -178,15 +181,15 @@ class DockerMethod(BaseMethod):
         put(files['public_key'], '/tmp')
         run('cat /tmp/'+os.path.basename(files['public_key'])+' >> /root/.ssh/authorized_keys')
         run('rm /tmp/'+os.path.basename(files['public_key']))
-        print green('Copied keyfile to docker.')
+        log.info('Copied keyfile to docker.')
 
       if files['authorized_keys']:
         put(files['authorized_keys'], '/root/.ssh/authorized_keys')
-        print green('Copied authorized keys to docker.')
+        log.info('Copied authorized keys to docker.')
 
       if files['known_hosts']:
         put(files['known_hosts'], '/root/.ssh/known_hosts')
-        print green('Copied known hosts to docker.')
+        log.info('Copied known hosts to docker.')
 
       run('chmod 700 /root/.ssh')
 
@@ -219,7 +222,7 @@ class DockerMethod(BaseMethod):
               if line.find('RUNNING'):
                 count_running += 1
           if count_services == count_running:
-            print green('Services up and running!')
+            log.info('Services up and running!')
             break;
 
       except:
@@ -232,7 +235,7 @@ class DockerMethod(BaseMethod):
           print "Wait for 5 secs and try again."
           time.sleep(5)
         else:
-          print red("Supervisord not coming up at all")
+          log.error("Supervisord not coming up at all")
           break
 
   def listAvailableCommands(self, config):
@@ -253,7 +256,7 @@ class DockerMethod(BaseMethod):
   def runCommand(self, config, **kwargs):
     command = kwargs['command']
     if not command:
-      print red('Missing command for docker-task.')
+      log.error('Missing command for docker-task.')
       self.listAvailableCommands(config)
       exit(1)
 
@@ -265,11 +268,11 @@ class DockerMethod(BaseMethod):
 
     docker_config = self.getDockerConfig(config)
     if not docker_config:
-      print red('Missing or incorrect docker-configuration in "%s"' % config['config_name'])
+      log.error('Missing or incorrect docker-configuration in "%s"' % config['config_name'])
       exit(1)
 
     if command not in docker_config['tasks']:
-      print red('Can\'t find  docker-command "%s"'  % ( command ))
+      log.error('Can\'t find  docker-command "%s"'  % ( command ))
       self.listAvailableCommands(config)
       exit(1)
 

--- a/lib/methods/docker.py
+++ b/lib/methods/docker.py
@@ -1,5 +1,5 @@
 import logging
-log = logging.getLogger('fabalicious.docker')
+log = logging.getLogger('fabric.fabalicious.docker')
 
 from base import BaseMethod
 from fabric.api import *

--- a/lib/methods/drupalconsole.py
+++ b/lib/methods/drupalconsole.py
@@ -4,7 +4,6 @@ log = logging.getLogger('fabalicious.drupalconsole')
 from base import BaseMethod
 from fabric.api import *
 from lib.utils import SSHTunnel, RemoteSSHTunnel
-from fabric.colors import green, red
 from lib import configuration
 from fabric.contrib.files import exists
 

--- a/lib/methods/drupalconsole.py
+++ b/lib/methods/drupalconsole.py
@@ -1,5 +1,5 @@
 import logging
-log = logging.getLogger('fabalicious.drupalconsole')
+log = logging.getLogger('fabric.fabalicious.drupalconsole')
 
 from base import BaseMethod
 from fabric.api import *

--- a/lib/methods/drupalconsole.py
+++ b/lib/methods/drupalconsole.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger('fabalicious.drupalconsole')
+
 from base import BaseMethod
 from fabric.api import *
 from lib.utils import SSHTunnel, RemoteSSHTunnel
@@ -26,7 +29,7 @@ class DrupalConsoleMethod(BaseMethod):
       self.run('chmod +x /usr/local/bin/drupal')
       self.run('drupal init')
 
-      print green('Drupal Console installed successfully.')
+      log.info('Drupal Console installed successfully.')
 
   def run_drupalconsole(self, config, command):
     self.setRunLocally(config)
@@ -44,4 +47,3 @@ class DrupalConsoleMethod(BaseMethod):
         self.run_install(config)
         return
     self.run_drupalconsole(config, kwargs['command'])
-

--- a/lib/methods/drush.py
+++ b/lib/methods/drush.py
@@ -229,7 +229,7 @@ class DrushMethod(BaseMethod):
       else:
         self.run_drush('sql-cli < ' + sql_name_target)
 
-      print(green('SQL restored from "%s"' % sql_name_target))
+      log.info('SQL restored from "%s"' % sql_name_target)
 
 
   def copyDBFrom(self, config, source_config=False, **kwargs):

--- a/lib/methods/drush.py
+++ b/lib/methods/drush.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger('fabalicious.drush')
+
 from base import BaseMethod
 from fabric.api import *
 from fabric.state import output, env
@@ -81,7 +84,7 @@ class DrushMethod(BaseMethod):
         for ignore in ignores:
           content.remove(ignore)
 
-        print yellow('Ignoring %s while %s modules from %s' % (' '.join(ignores), 'enabling' if enable else 'disabling', file))
+        log.warning('Ignoring %s while %s modules from %s' % (' '.join(ignores), 'enabling' if enable else 'disabling', file))
 
       modules = ' '.join(content)
 
@@ -103,7 +106,7 @@ class DrushMethod(BaseMethod):
         uuid = configuration.getSettings('uuid')
 
       if not uuid:
-        print red('No uuid found in fabfile.yaml. config-import may fail!')
+        log.error('No uuid found in fabfile.yaml. config-import may fail!')
 
     with self.cd(config['siteFolder']):
       if config['type'] == 'dev':
@@ -195,7 +198,7 @@ class DrushMethod(BaseMethod):
     self.backupSql(config, filename)
     if config['supportsZippedBackups']:
       filename += '.gz'
-    print green('Database dump at "%s"' % filename)
+    log.info('Database dump at "%s"' % filename)
 
   def listBackups(self, config, results, **kwargs):
     files = self.list_remote_files(config['backupFolder'], ['*.sql', '*.sql.gz'])
@@ -297,12 +300,12 @@ class DrushMethod(BaseMethod):
 
 
     if 'database' not in config:
-      print red('Missing database configuration!')
+      log.error('Missing database configuration!')
       exit(1)
 
     configuration.validate_dict(['user', 'pass', 'name', 'host'], config['database'], 'Missing database configuration: ')
 
-    print green('Installing fresh database for "%s"' % config['config_name'])
+    log.info('Installing fresh database for "%s"' % config['config_name'])
 
     o = config['database']
 
@@ -381,7 +384,7 @@ class DrushMethod(BaseMethod):
     with self.cd(config['rootFolder']):
       self.run_quietly('rm -rf /tmp/drupal-update')
 
-    print green("Updated drupal successfully to '%s'." % (drupal_folder))
+    log.info("Updated drupal successfully to '%s'." % (drupal_folder))
 
   def waitForDatabase(self, config):
     self.setRunLocally(config)
@@ -400,7 +403,7 @@ class DrushMethod(BaseMethod):
       time.sleep(5)
       print "Wait another 5 secs for the database ({user}@{host}) ...".format(**config['database'])
 
-    print red('Database not available!')
+    log.error('Database not available!')
     return False
 
 
@@ -415,4 +418,3 @@ class DrushMethod(BaseMethod):
   def preflight(self, task, config, **kwargs):
     if task == 'install':
       self.waitForDatabase(config)
-

--- a/lib/methods/drush.py
+++ b/lib/methods/drush.py
@@ -1,5 +1,5 @@
 import logging
-log = logging.getLogger('fabalicious.drush')
+log = logging.getLogger('fabric.fabalicious.drush')
 
 from base import BaseMethod
 from fabric.api import *

--- a/lib/methods/drush.py
+++ b/lib/methods/drush.py
@@ -4,7 +4,6 @@ log = logging.getLogger('fabalicious.drush')
 from base import BaseMethod
 from fabric.api import *
 from fabric.state import output, env
-from fabric.colors import green, red, yellow
 from fabric.network import *
 from fabric.context_managers import settings as _settings
 from lib import configuration

--- a/lib/methods/files.py
+++ b/lib/methods/files.py
@@ -3,7 +3,6 @@ log = logging.getLogger('fabalicious.files')
 
 from base import BaseMethod
 from fabric.api import *
-from fabric.colors import green, red
 import datetime
 import os.path
 import re

--- a/lib/methods/files.py
+++ b/lib/methods/files.py
@@ -101,7 +101,7 @@ class FilesMethod(BaseMethod):
     with cd(config['filesFolder']):
       self.run_quietly('#!tar -xzPf ' + tar_file, 'Unpacking files')
 
-    print(green('files restored from ' + file['file']))
+    log.info('files restored from ' + file['file'])
 
   def rsync(self, source_config, target_config, folder = 'filesFolder'):
     if not target_config['supportsCopyFrom']:

--- a/lib/methods/files.py
+++ b/lib/methods/files.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger('fabalicious.files')
+
 from base import BaseMethod
 from fabric.api import *
 from fabric.colors import green, red
@@ -65,7 +68,7 @@ class FilesMethod(BaseMethod):
 
     if len(source_folders) > 0:
       self.tarFiles(config, filename, source_folders, 'backup')
-      print green('Files dumped into "%s"' % filename)
+      log.info('Files dumped into "%s"' % filename)
 
 
   def listBackups(self, config, results, **kwargs):
@@ -102,10 +105,10 @@ class FilesMethod(BaseMethod):
 
   def rsync(self, source_config, target_config, folder = 'filesFolder'):
     if not target_config['supportsCopyFrom']:
-      print red('The configuration "{c} does not support copyFrom'.format(c=source_config['config_name']))
+      log.error('The configuration "{c} does not support copyFrom'.format(c=source_config['config_name']))
       return
 
-    print green('Copying files from {f} to {t}'.format(f=source_config['config_name'], t=target_config['config_name']))
+    log.info('Copying files from {f} to {t}'.format(f=source_config['config_name'], t=target_config['config_name']))
 
 
     with cd(env.config['rootFolder']):
@@ -138,7 +141,7 @@ class FilesMethod(BaseMethod):
     if (exists(remotePath)):
       get(remotePath, localPath)
     else:
-      print red("Could not find file '%s' on remote!" % remotePath)
+      log.error("Could not find file '%s' on remote!" % remotePath)
 
   def copyFilesFrom(self, config, source_config=False, **kwargs):
     self.setRunLocally(config)

--- a/lib/methods/files.py
+++ b/lib/methods/files.py
@@ -1,5 +1,5 @@
 import logging
-log = logging.getLogger('fabalicious.files')
+log = logging.getLogger('fabric.fabalicious.files')
 
 from base import BaseMethod
 from fabric.api import *

--- a/lib/methods/git.py
+++ b/lib/methods/git.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger('fabalicious.git')
+
 from base import BaseMethod
 from fabric.api import *
 from fabric.colors import green, red
@@ -63,7 +66,7 @@ class GitMethod(BaseMethod):
     with self.runLocally(config), self.cd(config['gitRootFolder']):
 
       if not self.cleanWorkingCopy():
-        print red("Working copy is not clean, aborting.\n")
+        log.error("Working copy is not clean, aborting.\n")
         self.run('#!git status')
         exit(1)
 
@@ -121,11 +124,11 @@ class GitMethod(BaseMethod):
         repository = configuration.getSettings('repository')
 
       if not repository:
-        print red('Could not find \'repository\' in host configuration nor in settings')
+        log.error('Could not find \'repository\' in host configuration nor in settings')
         exit(1)
 
       if (self.exists(targetPath + '/.projectCreated')):
-        print green('Application already installed!');
+        log.info('Application already installed!');
         with self.cd(targetPath):
           self.run('#!git checkout %s' % config['branch'])
           self.run('#!git pull -q origin %s' % config['branch'])
@@ -141,4 +144,3 @@ class GitMethod(BaseMethod):
     if (stage == 'deleteCode'):
       targetPath = dockerConfig['rootFolder'] + '/' + config['docker']['projectFolder']
       sudo('rm -rf %s' % targetPath, shell=False)
-

--- a/lib/methods/git.py
+++ b/lib/methods/git.py
@@ -1,5 +1,5 @@
 import logging
-log = logging.getLogger('fabalicious.git')
+log = logging.getLogger('fabric.fabalicious.git')
 
 from base import BaseMethod
 from fabric.api import *

--- a/lib/methods/git.py
+++ b/lib/methods/git.py
@@ -3,7 +3,6 @@ log = logging.getLogger('fabalicious.git')
 
 from base import BaseMethod
 from fabric.api import *
-from fabric.colors import green, red
 from lib.utils import validate_dict
 from lib.configuration import data_merge
 from lib import configuration

--- a/lib/methods/git.py
+++ b/lib/methods/git.py
@@ -99,7 +99,7 @@ class GitMethod(BaseMethod):
     if commit:
       with self.runLocally(config):
         self.run('#!git checkout ' + commit)
-        print(green('source restored to ' + commit))
+        log.info('source restored to ' + commit)
 
 
   def createApp(self, config, stage, dockerConfig, **kwargs):

--- a/lib/methods/platform.py
+++ b/lib/methods/platform.py
@@ -3,7 +3,6 @@ log = logging.getLogger('fabalicious.platform')
 
 from base import BaseMethod
 from fabric.api import *
-from fabric.colors import green, red
 from lib import configuration
 from drush import DrushMethod
 

--- a/lib/methods/platform.py
+++ b/lib/methods/platform.py
@@ -1,5 +1,5 @@
 import logging
-log = logging.getLogger('fabalicious.platform')
+log = logging.getLogger('fabric.fabalicious.platform')
 
 from base import BaseMethod
 from fabric.api import *

--- a/lib/methods/platform.py
+++ b/lib/methods/platform.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger('fabalicious.platform')
+
 from base import BaseMethod
 from fabric.api import *
 from fabric.colors import green, red
@@ -25,7 +28,7 @@ class PlatformMethod(BaseMethod):
 
   def run_install(self, config, **kwargs):
     local('curl -sS https://platform.sh/cli/installer | php');
-    print green('platform.sh client installed successfully.')
+    log.info('platform.sh client installed successfully.')
 
   def run_platform(self, config, command):
       local('platform %s' % command)
@@ -44,5 +47,3 @@ class PlatformMethod(BaseMethod):
 
   def drush(self, config, **kwargs):
     self.shadowed_drush.drush(config, **kwargs)
-
-

--- a/lib/methods/scripts.py
+++ b/lib/methods/scripts.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger('fabalicious.scripts')
+
 from base import BaseMethod
 from fabric.api import *
 from fabric.contrib.files import exists
@@ -38,12 +41,12 @@ class ScriptMethod(BaseMethod):
     ok = True
     for line in commands:
       if pattern.search(line) != None:
-        print red('Found replacement-pattern in script-line "%s", aborting ...' % line)
+        log.error('Found replacement-pattern in script-line "%s", aborting ...' % line)
         ok = False
 
     for key in environment:
       if pattern.search(environment[key]) != None:
-        print red('Found replacement-pattern in environment "%s:%s", aborting ...' % (key, environment[key]))
+        log.error('Found replacement-pattern in environment "%s:%s", aborting ...' % (key, environment[key]))
         ok = False
 
     if not ok:
@@ -107,7 +110,7 @@ class ScriptMethod(BaseMethod):
     execute(command, *args, **kwargs)
 
   def runTaskCallback(self, context, *args, **kwargs):
-    print red('run_task is not supported anymore, use "execute(docker, <your_task>)"');
+    log.error('run_task is not supported anymore, use "execute(docker, <your_task>)"');
 
   def failOnErrorCallback(self, context, flag):
     if flag == '1':
@@ -123,8 +126,8 @@ class ScriptMethod(BaseMethod):
       folder_exists = exists(directory)
 
     if not folder_exists:
-      print red(message)
-      print red('Missing: %s' % directory)
+      log.error(message)
+      log.error('Missing: %s' % directory)
       exit(1);
 
 
@@ -162,7 +165,7 @@ class ScriptMethod(BaseMethod):
 
     return_code = self.runScriptImpl(root_folder, commands, config, runLocally, callbacks, environment, replacements)
     if return_code:
-      print red('Due to earlier errors quitting now.')
+      log.error('Due to earlier errors quitting now.')
       exit(return_code)
 
   def runTaskSpecificScript(self, taskName, config, **kwargs):
@@ -170,17 +173,17 @@ class ScriptMethod(BaseMethod):
     type = config['type']
 
     if type in common_scripts and isinstance(common_scripts[type], list):
-      print red("Found old-style common-scripts. Please regroup by common > taskName > type > commands.")
+      log.error("Found old-style common-scripts. Please regroup by common > taskName > type > commands.")
 
     if taskName in common_scripts:
       if type in common_scripts[taskName]:
         script = common_scripts[taskName][type]
-        print yellow('Running common script for task %s and type %s' % (taskName, type))
+        log.warning('Running common script for task %s and type %s' % (taskName, type))
         self.runScript(config, script=script)
 
     if taskName in config:
       script = config[taskName]
-      print yellow('Running host-script for task %s and type %s' % (taskName, type))
+      log.warning('Running host-script for task %s and type %s' % (taskName, type))
       self.runScript(config, script=script)
 
   def fallback(self, taskName, configuration, **kwargs):
@@ -192,7 +195,3 @@ class ScriptMethod(BaseMethod):
 
   def postflight(self, taskName, configuration, **kwargs):
     self.runTaskSpecificScript(taskName + "Finished", configuration, **kwargs)
-
-
-
-

--- a/lib/methods/scripts.py
+++ b/lib/methods/scripts.py
@@ -6,7 +6,6 @@ from fabric.api import *
 from fabric.contrib.files import exists
 from fabric.network import *
 from fabric.context_managers import settings as _settings
-from fabric.colors import green, red, yellow
 from lib import configuration
 import re, copy
 

--- a/lib/methods/scripts.py
+++ b/lib/methods/scripts.py
@@ -1,5 +1,5 @@
 import logging
-log = logging.getLogger('fabalicious.scripts')
+log = logging.getLogger('fabric.fabalicious.scripts')
 
 from base import BaseMethod
 from fabric.api import *

--- a/lib/methods/scripts.py
+++ b/lib/methods/scripts.py
@@ -71,6 +71,7 @@ class ScriptMethod(BaseMethod):
               arguments = func_args.split(',')
               arguments = map(lambda x: x.strip(), arguments)
 
+            log.debug('Executing "%s"' % func_name)
             if arguments:
               callbacks[func_name](state, *arguments)
             else:
@@ -79,6 +80,7 @@ class ScriptMethod(BaseMethod):
 
         if not handled:
           line = self.expandCommand(line)
+          log.debug('Running "%s"' % line)
           if state['warnOnly']:
             with warn_only():
               result = local(line) if runLocally else run(line)
@@ -177,12 +179,12 @@ class ScriptMethod(BaseMethod):
     if taskName in common_scripts:
       if type in common_scripts[taskName]:
         script = common_scripts[taskName][type]
-        log.warning('Running common script for task %s and type %s' % (taskName, type))
+        log.info('Running common script for task %s and type %s' % (taskName, type))
         self.runScript(config, script=script)
 
     if taskName in config:
       script = config[taskName]
-      log.warning('Running host-script for task %s and type %s' % (taskName, type))
+      log.info('Running host-script for task %s and type %s' % (taskName, type))
       self.runScript(config, script=script)
 
   def fallback(self, taskName, configuration, **kwargs):

--- a/lib/methods/slack.py
+++ b/lib/methods/slack.py
@@ -1,5 +1,5 @@
 import logging
-log = logging.getLogger('fabalicious.slack')
+log = logging.getLogger('fabric.fabalicious.slack')
 
 from base import BaseMethod
 from fabric.api import *

--- a/lib/methods/slack.py
+++ b/lib/methods/slack.py
@@ -3,7 +3,6 @@ log = logging.getLogger('fabalicious.slack')
 
 from base import BaseMethod
 from fabric.api import *
-from fabric.colors import green, red
 from lib import configuration
 import json
 import getpass

--- a/lib/methods/slack.py
+++ b/lib/methods/slack.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger('fabalicious.slack')
+
 from base import BaseMethod
 from fabric.api import *
 from fabric.colors import green, red
@@ -71,9 +74,9 @@ class SlackMethod(BaseMethod):
       attachments = json.dumps(attachments)
 
       slack.chat.post_message(slack_config['channel'], message, username=username, attachments=attachments, icon_emoji=slack_config['icon_emoji'])
-      print green('Slack-notification sent to %s.' % slack_config['channel'])
+      log.info('Slack-notification sent to %s.' % slack_config['channel'])
     except ImportError:
-      print red('Please install slacker on this machine: pip install slacker.')
+      log.error('Please install slacker on this machine: pip install slacker.')
 
 
 

--- a/lib/methods/ssh.py
+++ b/lib/methods/ssh.py
@@ -4,7 +4,6 @@ log = logging.getLogger('fabalicious.ssh')
 from base import BaseMethod
 from fabric.api import *
 from lib.utils import SSHTunnel, RemoteSSHTunnel
-from fabric.colors import green, red
 from fabric.network import *
 from lib import configuration
 import copy

--- a/lib/methods/ssh.py
+++ b/lib/methods/ssh.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger('fabalicious.ssh')
+
 from base import BaseMethod
 from fabric.api import *
 from lib.utils import SSHTunnel, RemoteSSHTunnel
@@ -106,7 +109,7 @@ class SSHMethod(BaseMethod):
         o['destHost'] = result['ip']
 
     if 'destHost' not in o or not o['destHost']:
-      print red('Could not get remote ip-address!')
+      log.error('Could not get remote ip-address!')
       self.tunnels[key]['creating'] = False
 
       return False
@@ -123,9 +126,9 @@ class SSHMethod(BaseMethod):
     self.tunnels[key]['creating'] = False
 
     if self.tunnels[key]['created']:
-      print green('Tunnel established')
+      log.info('Tunnel established')
     else:
-      print red('Tunnel creation failed')
+      log.error('Tunnel creation failed')
 
     return tunnel
 
@@ -170,13 +173,13 @@ class SSHMethod(BaseMethod):
   def doctor_ssh_connection(self, config):
     output = local('ssh -A -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o BatchMode=yes -o ConnectTimeout=5 -p {port} {user}@{host} echo ok'.format(**config), capture=True)
     if output.return_code != 0:
-      print red('Cannot connect to host! Please check if the host is running and reachable, and check if your public key is added to authorized_keys on the remote host.')
-      print red('Try: ssh -p {port} {user}@{host}'.format(**config))
-      print red('Try: ssh-copy-id -p {port} {user}@{host}'.format(**config))
-      print red('Try: ssh-keyscan -t rsa,dsa -p {port} -H {host} and add the lines to known_hosts if not already in place.'.format(**config))
+      log.error('Cannot connect to host! Please check if the host is running and reachable, and check if your public key is added to authorized_keys on the remote host.')
+      log.error('Try: ssh -p {port} {user}@{host}'.format(**config))
+      log.error('Try: ssh-copy-id -p {port} {user}@{host}'.format(**config))
+      log.error('Try: ssh-keyscan -t rsa,dsa -p {port} -H {host} and add the lines to known_hosts if not already in place.'.format(**config))
       return False
     else:
-      print green("Can connect to host {host} at port {port}!".format(**config))
+      log.info("Can connect to host {host} at port {port}!".format(**config))
       return True
 
 
@@ -185,18 +188,18 @@ class SSHMethod(BaseMethod):
       print "Check SSH keyforwading: ",
       output = local(' echo xx${SSH_AUTH_SOCK}xx', capture=True)
       if output.stdout.strip() == 'xxxx':
-        print red('SSH Keyforwarding is not working correctly, SSH_AUTH_SOCK is not available!')
+        log.error('SSH Keyforwarding is not working correctly, SSH_AUTH_SOCK is not available!')
         exit(1)
       else:
-        print green('SSH Keyforwarding seems to work.')
+        log.info('SSH Keyforwarding seems to work.')
 
       print "Check SSH key-agent: ",
       output = local('ssh-add -l', capture=True)
       if output.return_code != 0:
-        print red('SSH key-agent has no private keys, please add it via "ssh-add".')
+        log.error('SSH key-agent has no private keys, please add it via "ssh-add".')
         exit(1)
       else:
-        print green('SSH key-agent has one or more private keys.')
+        log.info('SSH key-agent has one or more private keys.')
 
       if 'sshTunnel' in config:
         print "Check SSH tunnel: ",
@@ -240,17 +243,9 @@ class SSHMethod(BaseMethod):
         print "Check SSH-connection from %s to %s: " % (config['config_name'], remote_config['config_name']),
         output = local(cmd, capture=True)
         if output.return_code != 0:
-          print red('Connection failed!')
-          print red('Try: %s' % cmd)
+          log.error('Connection failed!')
+          log.error('Try: %s' % cmd)
           print output.stdout
           exit(1)
         else:
-          print green('Connection established!')
-
-
-
-
-
-
-
-
+          log.info('Connection established!')

--- a/lib/methods/ssh.py
+++ b/lib/methods/ssh.py
@@ -1,5 +1,5 @@
 import logging
-log = logging.getLogger('fabalicious.ssh')
+log = logging.getLogger('fabric.fabalicious.ssh')
 
 from base import BaseMethod
 from fabric.api import *

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,3 +1,6 @@
+import logging
+log = logging.getLogger('fabalicious.utils')
+
 from fabric.api import *
 import subprocess, shlex, atexit, time
 import time
@@ -31,7 +34,7 @@ class TunnelBase:
         terminated = True
 
     if not connectionEstablished:
-      print red("Could not establish tunnel with command %s" % self.cmd)
+      log.error("Could not establish tunnel with command %s" % self.cmd)
       print output
       exit(1)
 
@@ -140,4 +143,3 @@ def validate_dict(keys, dict, section=False):
         result[key] = 'Key is missing'
 
   return result
-

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -154,6 +154,7 @@ def log_level_lookup(x):
         'log_level:WARNING': logging.WARNING,
         'log_level:ERROR': logging.ERROR,
         'log_level:CRITICAL': logging.CRITICAL,
+        '--show=debug': logging.DEBUG,
     };
     try:
       return lookup[x]

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -149,11 +149,11 @@ def validate_dict(keys, dict, section=False):
 
 def log_level_lookup(x):
     lookup = {
-        'log_level:DEBUG': logging.DEBUG,
-        'log_level:INFO': logging.INFO,
-        'log_level:WARNING': logging.WARNING,
-        'log_level:ERROR': logging.ERROR,
-        'log_level:CRITICAL': logging.CRITICAL,
+        'logLevel:DEBUG': logging.DEBUG,
+        'logLevel:INFO': logging.INFO,
+        'logLevel:WARNING': logging.WARNING,
+        'logLevel:ERROR': logging.ERROR,
+        'logLevel:CRITICAL': logging.CRITICAL,
         '--show=debug': logging.DEBUG,
     };
     try:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -4,7 +4,6 @@ log = logging.getLogger('fabalicious.utils')
 from fabric.api import *
 import subprocess, shlex, atexit, time
 import time
-from fabric.colors import red
 
 ssh_no_strict_key_host_checking_params = '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null '
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -161,16 +161,18 @@ def log_level_lookup(x):
     except Exception as e:
       return None
 
+def setup_global_logging(root_folder, env_key_level="LOG_LVL"):
+    """Setup logging configuration globally
+
+    """
+    log_level = os.getenv(env_key_level, None)
+    setup_logging(root_folder, log_level)
+
 def setup_logging(root_folder, log_level=None, env_key="LOG_CFG"):
     """Setup logging configuration
 
     """
     default_path = root_folder + '/logging.yaml'
-    if log_level is None:
-      for arg in sys.argv:
-        level = log_level_lookup(arg)
-        if level:
-          log_level = level
     path = default_path
     value = os.getenv(env_key, None)
     if value:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -171,9 +171,6 @@ def setup_logging(root_folder, log_level=None, env_key="LOG_CFG"):
         level = log_level_lookup(arg)
         if level:
           log_level = level
-    for arg in sys.argv:
-      if arg == "--show=debug":
-        log_level = logging.DEBUG
     path = default_path
     value = os.getenv(env_key, None)
     if value:

--- a/logging.yaml
+++ b/logging.yaml
@@ -1,0 +1,26 @@
+version: 1
+disable_existing_loggers: False
+formatters:
+    simple:
+        format: "%(message)s"
+handlers:
+    console:
+        class: lib.colorize.ColorizingStreamHandler
+        level: DEBUG
+        formatter: simple
+        stream: ext://sys.stdout
+loggers:
+    fabric:
+        handlers: [console]
+        propagate: no
+    paramiko:
+        level: ERROR
+        handlers: [console]
+        propagate: no
+    yapsy:
+        level: ERROR
+        handlers: [console]
+        propagate: no
+root:
+    level: INFO
+    handlers: [console]


### PR DESCRIPTION
Change various print statement to use logging provided by python.
1. The logger is nested under fabric (which also uses logging).
2. Logger for submodules are nested under `fabric.fabalicious` with unique name, so it is possible for an external listener to pinpoint the source of error message.
3. To avoid any external dependency a helper class have been used (links at the bottom of description).
4. `fab config:mbb ssh` now shows what paramiko.transport have been trying to communicate for years.
5. `fab config:mbb ssh --show=debug` will show some debug info.

Used : https://bitbucket.org/vinay.sajip/logutils/src/99531cde4d3b6870e55f891e68fdc1e702f9b4d8/logutils/colorize.py?at=default&fileviewer=file-view-default
License : https://bitbucket.org/vinay.sajip/logutils/src/99531cde4d3b6870e55f891e68fdc1e702f9b4d8/LICENSE.txt?at=default&fileviewer=file-view-default