### PR TITLE
WIP: Refactor local plugins discovery

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -14,16 +14,17 @@ import time
 import datetime
 import sys
 from fabric.main import list_commands
+
+# Import our modules.
+root_folder = os.path.dirname(os.path.realpath(os.path.dirname(__file__) + '/fabfile.py'))
+sys.path.append(root_folder)
+
 from lib import configuration
 from lib import blueprints
 from lib import utils
 from lib import plugins
 
-# Import our modules.
-root_folder = os.path.dirname(os.path.realpath(os.path.dirname(__file__) + '/fabfile.py'))
 configuration.setRootDir(root_folder)
-sys.path.append(configuration.getRootDir())
-
 # @TODO check with @huber if this assignment is necessary.
 configuration.fabfile_basedir = root_folder
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -14,15 +14,15 @@ import time
 import datetime
 import sys
 from fabric.main import list_commands
+from lib import configuration
+from lib import blueprints
+from lib import utils
+from lib import plugins
 
 # Import our modules.
 root_folder = os.path.dirname(os.path.realpath(os.path.dirname(__file__) + '/fabfile.py'))
 configuration.setRootDir(root_folder)
 sys.path.append(configuration.getRootDir())
-from lib import configuration
-from lib import blueprints
-from lib import utils
-from lib import plugins
 
 # @TODO check with @huber if this assignment is necessary.
 configuration.fabfile_basedir = root_folder

--- a/fabfile.py
+++ b/fabfile.py
@@ -24,6 +24,7 @@ from lib import blueprints
 from lib import utils
 from lib import plugins
 
+# @TODO check with @huber if this assignment is necessary.
 configuration.fabfile_basedir = root_folder
 
 utils.setup_global_logging()

--- a/fabfile.py
+++ b/fabfile.py
@@ -17,7 +17,8 @@ from fabric.main import list_commands
 
 # Import our modules.
 root_folder = os.path.dirname(os.path.realpath(os.path.dirname(__file__) + '/fabfile.py'))
-sys.path.append(root_folder)
+configuration.setRootDir(root_folder)
+sys.path.append(configuration.getRootDir())
 from lib import configuration
 from lib import blueprints
 from lib import utils
@@ -25,13 +26,13 @@ from lib import plugins
 
 configuration.fabfile_basedir = root_folder
 
-utils.setup_global_logging(root_folder)
+utils.setup_global_logging()
 
 from lib import methods
 
 @task
 def logLevel(level=None):
-    utils.setup_logging(root_folder, log_level = level)
+    utils.setup_logging(log_level = level)
 
 @task
 def config(configName='local'):
@@ -517,5 +518,5 @@ def fish_completions():
       print "docker:" + key
 
 # Load Plugins towards the end to avoid variable name space corruption.
-for taskName, obj in plugins.getTasks(root_folder).iteritems():
+for taskName, obj in plugins.getTasks().iteritems():
   exec("%s=obj" % (taskName))

--- a/lib/configuration/__init__.py
+++ b/lib/configuration/__init__.py
@@ -463,10 +463,13 @@ def getAll():
 
   return root_data
 
-def getSettings(key, defaultValue = False):
+def getSettings(key = False, defaultValue = False):
   """Helper function to read configuration from fabfiles.
   Allow use of dot operator (".") to get nested value.
   """
+  if key is False:
+    return getAll()
+
   settings = defaultValue
   keys = key.split('.')
   firstRunFlag = True

--- a/lib/configuration/__init__.py
+++ b/lib/configuration/__init__.py
@@ -22,6 +22,7 @@ env.forward_agent = True
 env.use_shell = False
 
 fabfile_basedir = False
+fabalicious_rootdir = None
 offline = False
 cache = {}
 
@@ -489,6 +490,17 @@ def getBaseDir():
   global fabfile_basedir
   return fabfile_basedir
 
+def getRootDir():
+  """Retrieves the root directory of fabalicious, where fabfile.py is located.
+  """
+  global fabalicious_rootdir
+  return fabalicious_rootdir
+
+def setRootDir(root_dir):
+  """Set the root directory of fabalicious, where fabfile.py is located.
+  """
+  global fabalicious_rootdir
+  fabalicious_rootdir = root_dir
 
 def getDockerConfig(docker_config_name, runLocally = False, printErrors=True):
 

--- a/lib/configuration/__init__.py
+++ b/lib/configuration/__init__.py
@@ -463,7 +463,7 @@ def getAll():
 
   return root_data
 
-def getSetting(key, defaultValue = False):
+def getSettings(key, defaultValue = False):
   """Helper function to read configuration from fabfiles.
   Allow use of dot operator (".") to get nested value.
   """
@@ -473,12 +473,12 @@ def getSetting(key, defaultValue = False):
   for key in keys:
     if firstRunFlag:
       firstRunFlag = False
-      settings = getSettings(key, defaultValue)
+      settings = _getSetting(key, defaultValue)
     else:
       settings = settings[key] if key in settings else defaultValue
   return settings
 
-def getSettings(key = False, defaultValue = False):
+def _getSetting(key = False, defaultValue = False):
   settings = getAll()
   if key:
     return settings[key] if key in settings else defaultValue

--- a/lib/configuration/__init__.py
+++ b/lib/configuration/__init__.py
@@ -485,22 +485,23 @@ def getSettings(key = False, defaultValue = False):
   else:
     return settings
 
-
 def getBaseDir():
+  """Retrieves the directory where fabfile.yaml is located.
+  """
   global fabfile_basedir
   return fabfile_basedir
-
-def getRootDir():
-  """Retrieves the root directory of fabalicious, where fabfile.py is located.
-  """
-  global fabalicious_rootdir
-  return fabalicious_rootdir
 
 def setRootDir(root_dir):
   """Set the root directory of fabalicious, where fabfile.py is located.
   """
   global fabalicious_rootdir
   fabalicious_rootdir = root_dir
+
+def getRootDir():
+  """Retrieves the root directory of fabalicious, where fabfile.py is located.
+  """
+  global fabalicious_rootdir
+  return fabalicious_rootdir
 
 def getDockerConfig(docker_config_name, runLocally = False, printErrors=True):
 

--- a/lib/methods/__init__.py
+++ b/lib/methods/__init__.py
@@ -38,7 +38,7 @@ for method in methodClasses:
   configuration.addGlobalSettings(method.getGlobalSettings())
 
 # get custom methods
-customMethods = plugins.getMethods(configuration.fabfile_basedir)
+customMethods = plugins.getMethods()
 for methodName, obj in customMethods.iteritems():
   obj.setNameAndFactory(methodName, sys.modules[__name__])
   configuration.addGlobalSettings(obj.getGlobalSettings())

--- a/lib/plugins/__init__.py
+++ b/lib/plugins/__init__.py
@@ -3,20 +3,15 @@ from lib import configuration
 import logging
 log = logging.getLogger('fabric.fabalicious.plugins')
 
-def loadPlugins(root_folder, settings_name, folder_name, plugin_name, categories_filter):
+def loadPlugins(root_folder, categories_filter):
   from yapsy.PluginManager import PluginManager
-
-  plugin_dirs = []
-  if configuration.getSettings(settings_name):
-    plugin_dirs.append(configuration.fabfile_basedir + '/' + configuration.getSettings(settings_name))
-
-  plugin_dirs.append(configuration.fabfile_basedir + '/.fabalicious/' + folder_name)
-  plugin_dirs.append(configuration.fabfile_basedir + '/plugins/' + folder_name)
-
-  plugin_dirs.append(expanduser("~") + '/.fabalicious/plugins/' + folder_name)
-  plugin_dirs.append(root_folder + '/plugins/' + folder_name)
-  log.debug("Looking for %s-plugins in %s" % (plugin_name, ", ".join(plugin_dirs)))
-
+  localPluginsPath = configuration.getSetting("customPlugins.path", '.tools/fabalicious/plugins')
+  plugin_dirs = [
+    configuration.fabfile_basedir + '/' + localPluginsPath,
+    configuration.fabfile_basedir + '/.fabalicious',
+    expanduser("~") + '/.fabalicious/plugins',
+    root_folder + '/plugins',
+  ]
   manager = PluginManager()
   manager.setPluginPlaces(plugin_dirs)
   manager.setCategoriesFilter(categories_filter)
@@ -43,8 +38,8 @@ def getTasks(root_folder):
   try:
     __import__('imp').find_module('yapsy')
     from task import ITaskPlugin
-
-    return loadPlugins(root_folder, 'customTasksFolder', 'tasks', 'task', { "Task": ITaskPlugin })
+    log.debug('Load Tasks plugins')
+    return loadPlugins(root_folder, { "Task": ITaskPlugin })
 
   except ImportError:
     log.warning('Custom plugins disabled, as yapsy is not installed!')
@@ -55,8 +50,8 @@ def getMethods(root_folder):
   try:
     __import__('imp').find_module('yapsy')
     from method import IMethodPlugin
-
-    return loadPlugins(root_folder, 'customMethodsFolder', 'methods', 'method', { "Method": IMethodPlugin })
+    log.debug('Load Method plugins')
+    return loadPlugins(root_folder, { "Method": IMethodPlugin })
 
   except ImportError:
     log.warning('Custom plugins disabled, as yapsy is not installed!')

--- a/lib/plugins/__init__.py
+++ b/lib/plugins/__init__.py
@@ -5,7 +5,7 @@ log = logging.getLogger('fabric.fabalicious.plugins')
 
 def loadPlugins(categories_filter):
   from yapsy.PluginManager import PluginManager
-  localPluginsPath = configuration.getSetting("customPlugins.path", '.tools/fabalicious/plugins')
+  localPluginsPath = configuration.getSettings("customPlugins.path", '.tools/fabalicious/plugins')
   plugin_dirs = [
     configuration.getBaseDir() + '/' + localPluginsPath,
     configuration.getBaseDir() + '/.fabalicious',

--- a/lib/plugins/__init__.py
+++ b/lib/plugins/__init__.py
@@ -3,15 +3,16 @@ from lib import configuration
 import logging
 log = logging.getLogger('fabric.fabalicious.plugins')
 
-def loadPlugins(root_folder, categories_filter):
+def loadPlugins(categories_filter):
   from yapsy.PluginManager import PluginManager
   localPluginsPath = configuration.getSetting("customPlugins.path", '.tools/fabalicious/plugins')
   plugin_dirs = [
     configuration.getBaseDir() + '/' + localPluginsPath,
     configuration.getBaseDir() + '/.fabalicious',
     expanduser("~") + '/.fabalicious/plugins',
-    root_folder + '/plugins',
+    configuration.getRooDir() + '/plugins',
   ]
+
   manager = PluginManager()
   manager.setPluginPlaces(plugin_dirs)
   manager.setCategoriesFilter(categories_filter)
@@ -34,24 +35,24 @@ def loadPlugins(root_folder, categories_filter):
   return result
 
 
-def getTasks(root_folder):
+def getTasks():
   try:
     __import__('imp').find_module('yapsy')
     from task import ITaskPlugin
     log.debug('Load Tasks plugins')
-    return loadPlugins(root_folder, { "Task": ITaskPlugin })
+    return loadPlugins({ "Task": ITaskPlugin })
 
   except ImportError:
     log.warning('Custom plugins disabled, as yapsy is not installed!')
     return {}
 
 
-def getMethods(root_folder):
+def getMethods():
   try:
     __import__('imp').find_module('yapsy')
     from method import IMethodPlugin
     log.debug('Load Method plugins')
-    return loadPlugins(root_folder, { "Method": IMethodPlugin })
+    return loadPlugins({ "Method": IMethodPlugin })
 
   except ImportError:
     log.warning('Custom plugins disabled, as yapsy is not installed!')

--- a/lib/plugins/__init__.py
+++ b/lib/plugins/__init__.py
@@ -10,7 +10,7 @@ def loadPlugins(categories_filter):
     configuration.getBaseDir() + '/' + localPluginsPath,
     configuration.getBaseDir() + '/.fabalicious',
     expanduser("~") + '/.fabalicious/plugins',
-    configuration.getRooDir() + '/plugins',
+    configuration.getRootDir() + '/plugins',
   ]
 
   manager = PluginManager()

--- a/lib/plugins/__init__.py
+++ b/lib/plugins/__init__.py
@@ -7,8 +7,8 @@ def loadPlugins(root_folder, categories_filter):
   from yapsy.PluginManager import PluginManager
   localPluginsPath = configuration.getSetting("customPlugins.path", '.tools/fabalicious/plugins')
   plugin_dirs = [
-    configuration.fabfile_basedir + '/' + localPluginsPath,
-    configuration.fabfile_basedir + '/.fabalicious',
+    configuration.getBaseDir() + '/' + localPluginsPath,
+    configuration.getBaseDir() + '/.fabalicious',
     expanduser("~") + '/.fabalicious/plugins',
     root_folder + '/plugins',
   ]
@@ -28,7 +28,7 @@ def loadPlugins(root_folder, categories_filter):
       for alias in plugin.plugin_object.aliases:
         result[alias] = plugin.plugin_object
     elif hasattr(plugin.plugin_object, 'alias'):
-      result[plugin.plugin_object.alias] = plugin.plugin_object  
+      result[plugin.plugin_object.alias] = plugin.plugin_object
     else:
       result[plugin.name] = plugin.plugin_object
   return result

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -161,18 +161,18 @@ def log_level_lookup(x):
     except Exception as e:
       return None
 
-def setup_global_logging(root_folder, env_key_level="LOG_LVL"):
+def setup_global_logging(env_key_level="LOG_LVL"):
     """Setup logging configuration globally
 
     """
     log_level = os.getenv(env_key_level, None)
-    setup_logging(root_folder, log_level)
+    setup_logging(log_level)
 
-def setup_logging(root_folder, log_level=None, env_key="LOG_CFG"):
+def setup_logging(log_level=None, env_key="LOG_CFG"):
     """Setup logging configuration
 
     """
-    default_path = root_folder + '/logging.yaml'
+    default_path = configuration.getRootDir() + '/logging.yaml'
     path = default_path
     value = os.getenv(env_key, None)
     if value:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -8,6 +8,7 @@ import os
 import sys
 import yaml
 import logging.config
+import configuration
 
 ssh_no_strict_key_host_checking_params = '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null '
 


### PR DESCRIPTION
The motivation of this refactor stems from the following piece of assignment in fabfile.py

```
configuration.fabfile_basedir = root_folder
```
According to the above assignment, `fabfile_basedir` is supposed to store the directory where `fabfile.py` resides. However, later down the lane, it gets assigned the directory where the command was executed from. Which is usually the directory where fabfile.yaml is located.

Also root_folder was being passed a lot among various function.

So the PR,

- TODO : Need to define what fabfile_basedir should hold.
- root_folder is being moved to configuration, where it can be accessed via `configuration.getRootDir()`
- Refactored code to use above function