### PR TITLE
Fix looping through empty list of commands

### DIFF
--- a/lib/methods/base.py
+++ b/lib/methods/base.py
@@ -94,10 +94,10 @@ class BaseMethod(object):
   def expandCommands(self, commands, replacements):
     parsed_commands = []
     pattern = re.compile('|'.join(re.escape(key) for key in replacements.keys()))
-    for line in commands:
-      result = pattern.sub(lambda x: replacements[x.group()], line)
-      parsed_commands.append(result)
-
+    if commands:
+      for line in commands:
+        result = pattern.sub(lambda x: replacements[x.group()], line)
+        parsed_commands.append(result)
     return parsed_commands
   def addPasswordToFabricCache(self, user, host, port, password, **kwargs):
     host_string = join_host_strings(user, host, port)


### PR DESCRIPTION
When an empty list of commands is supplied, fabalicious borks.
Eg. consider the below case for `dev`
```
  reset:
    dev:
    stage:
      - execute(script, patternlab)
```
so when running reset, it borks and gives following error.
```
Running common script for task reset and type dev
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/fabric/main.py", line 757, in main
    *args, **kwargs
  File "/usr/local/lib/python2.7/site-packages/fabric/tasks.py", line 386, in execute
    multiprocessing
  File "/usr/local/lib/python2.7/site-packages/fabric/tasks.py", line 276, in _execute
    return task.run(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/fabric/tasks.py", line 173, in run
    return self.wrapped(*args, **kwargs)
  File "/Users/shibindas/work/multibasebox/multibasebox/projects/fr012-bi-france/fabfile.py", line 143, in reset
    methods.runTask(configuration.current(), 'reset', **kwargs)
  File "/Users/shibindas/work/multibasebox/multibasebox/projects/fr012-bi-france/vendor/factorial-io/fabalicious/lib/methods/__init__.py", line 131, in runTask
    runTaskImpl(configuration['needs'], taskName, configuration, True, **kwargs);
  File "/Users/shibindas/work/multibasebox/multibasebox/projects/fr012-bi-france/vendor/factorial-io/fabalicious/lib/methods/__init__.py", line 151, in runTaskImpl
    callImpl(methodName, taskName, configuration, True, **kwargs)
  File "/Users/shibindas/work/multibasebox/multibasebox/projects/fr012-bi-france/vendor/factorial-io/fabalicious/lib/methods/__init__.py", line 107, in callImpl
    result = fn(configuration, **kwargs)
  File "/Users/shibindas/work/multibasebox/multibasebox/projects/fr012-bi-france/vendor/factorial-io/fabalicious/lib/methods/drush.py", line 179, in reset
    fn('reset', config, **kwargs)
  File "/Users/shibindas/work/multibasebox/multibasebox/projects/fr012-bi-france/vendor/factorial-io/fabalicious/lib/methods/scripts.py", line 190, in runTaskSpecificScript
    self.runScript(config, script=script)
  File "/Users/shibindas/work/multibasebox/multibasebox/projects/fr012-bi-france/vendor/factorial-io/fabalicious/lib/methods/scripts.py", line 165, in runScript
    commands = self.expandCommands(script, replacements)
  File "/Users/shibindas/work/multibasebox/multibasebox/projects/fr012-bi-france/vendor/factorial-io/fabalicious/lib/methods/base.py", line 97, in expandCommands
    for line in commands:
TypeError: 'NoneType' object is not iterable
Disconnecting from bi-france.test:36997... done.
```