### PR TITLE
WIP: better multisite support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,18 +4,18 @@
 
 ### new
 
-* new task `set`. This task requires a list of blueprint-variants or the keyword `all`. It will spawn multiple fabalicious commands which will run in parallel if `processes` is set to a value greater than 1.
+* new task `variants`. This task requires a list of blueprint-variants or the keyword `all`. It will spawn multiple fabalicious commands which will run in parallel if `processes` is set to a value greater than 1.
   
     Some examples:
   
     ```  
-    fab config:mbb set:all drush:"cc all"
+    fab config:mbb variants:all drush:"cc all"
     ```
   
     Will run the drush command for all variants of the blueprint-configuration mbb.
     
     ```
-    fab config:mbb set:de,fr,it,processes=3 drush:"cc all"
+    fab config:mbb variants:de,fr,it,processes=3 drush:"cc all"
     ``` 
     
     This command will run the drush command on a subsets of variants, namely de, fr and it. It will spawn 3 concurrent processes.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,30 @@
 # Changelog
 
+## 2.x.x
+
+### new
+
+* new task `set`. This task requires a list of blueprint-variants or the keyword `all`. It will spawn multiple fabalicious commands which will run in parallel if `processes` is set to a value greater than 1.
+  
+    Some examples:
+  
+    ```  
+    fab config:mbb set:all drush:"cc all"
+    ```
+  
+    Will run the drush command for all variants of the blueprint-configuration mbb.
+    
+    ```
+    fab config:mbb set:de,fr,it,processes=3 drush:"cc all"
+    ``` 
+    
+    This command will run the drush command on a subsets of variants, namely de, fr and it. It will spawn 3 concurrent processes.
+
 ## 2.4.0
 
 ### new
 
-* new section in fabfile.yaml called `blueprints`. THis section allows the usage of a given sets of blueprints as normal config. That means, they will get listed and work wirh autocomplete
+* new section in fabfile.yaml called `blueprints`. This section allows the usage of a given sets of blueprints as normal config. That means, they will get listed and work with autocomplete
 
       ```
       blueprints:

--- a/plugins/set/set.py
+++ b/plugins/set/set.py
@@ -12,21 +12,6 @@ from contextlib import contextmanager
 
 globallock = Lock()
 
-class LoggerWriter:
-  def __init__(self, level):
-    # self.level is really like using log.debug(message)
-    # at least in my case
-    self.level = level
-
-  def write(self, message):
-    # if statement reduces the amount of newlines that are
-    # printed to the logger
-    if message != '\n':
-      self.level(message)
-
-  def flush(self):
-    pass
-
 @contextmanager
 def poolcontext(*args, **kwargs):
     pool = Pool(*args, **kwargs)

--- a/plugins/set/set.py
+++ b/plugins/set/set.py
@@ -1,0 +1,121 @@
+import logging
+log = logging.getLogger('fabric.fabalicious.set')
+from lib.plugins.task import ITaskPlugin
+from lib import configuration
+
+import sys
+import os
+import subprocess
+from multiprocessing import Pool, Lock
+from contextlib import contextmanager
+
+
+globallock = Lock()
+
+class LoggerWriter:
+  def __init__(self, level):
+    # self.level is really like using log.debug(message)
+    # at least in my case
+    self.level = level
+
+  def write(self, message):
+    # if statement reduces the amount of newlines that are
+    # printed to the logger
+    if message != '\n':
+      self.level(message)
+
+  def flush(self):
+    pass
+
+@contextmanager
+def poolcontext(*args, **kwargs):
+    pool = Pool(*args, **kwargs)
+    yield pool
+    pool.terminate()
+
+def runFabalicious(args):
+  config = args.pop(0)
+  log.info(config + ": Running " + " ".join(args))
+  process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  def check_io():
+    captured = ''
+    while True:
+      output = process.stdout.readline().decode()
+      if output:
+        captured += output
+        log.debug(config + ": " + output.replace("\n", ""))
+      else:
+        break
+    return captured
+
+  # keep checking stdout/stderr until the child exits
+  while process.poll() is None:
+    captured = check_io()
+
+  # Log the result for humans
+  globallock.acquire()
+  log.info(config + ": Results of " + " ".join(args))
+  for line in captured.splitlines():
+    log.info(config + ": " + line)
+
+  globallock.release()
+
+class Set(ITaskPlugin):
+  def run(self, *args, **kwargs):
+    num_processes = int(kwargs['processes']) if 'processes' in kwargs else 1
+
+    if len(args) < 1:
+      log.error('Please provide a list of blueprints or \'all\'')
+      exit(1)
+
+    blueprints = configuration.getSettings('blueprints')
+    config = configuration.current()
+    if not config:
+      log.error('set needs a valid configuration!')
+      exit(1)
+
+    config_name = configuration.current('config_name')
+
+    found = False
+    for b in blueprints:
+      if b['configName'] == config_name:
+        found = b
+
+    if not found:
+      log.error('%s not found in blueprints-section' % config_name)
+      exit(1)
+
+    variants = []
+    if args[0] == 'all':
+      variants = b['variants']
+    else:
+      for arg in args:
+        if arg in b['variants']:
+          variants.append(arg)
+        else:
+          log.error("Could not find variant %s in blueprint.variants" % arg)
+          exit(1)
+
+    commands = []
+    for variant in variants:
+      command = [
+        variant,
+        sys.argv[0],
+        sys.argv[1],
+        'blueprint:' + variant
+      ]
+      command = command + sys.argv[3:]
+      commands.append(command)
+
+      log.info(" ".join(command))
+    log.info("Using %s parallel processes" % num_processes)
+    result = raw_input('Do you want to execute above listed commands? (Y/N) ')
+
+    if (result[:1] != 'y') and (result[:1] != 'Y'):
+      exit(0)
+
+    with poolcontext(processes=num_processes) as pool:
+      pool.map(runFabalicious, commands)
+
+    exit(0)
+

--- a/plugins/set/set.py
+++ b/plugins/set/set.py
@@ -46,8 +46,8 @@ def runFabalicious(args):
   log.info('')
   log.info('')
 
-
   globallock.release()
+
 
 class Set(ITaskPlugin):
   def run(self, *args, **kwargs):

--- a/plugins/set/set.py
+++ b/plugins/set/set.py
@@ -54,9 +54,13 @@ def runFabalicious(args):
 
   # Log the result for humans
   globallock.acquire()
+  log.info('')
   log.info(config + ": Results of " + " ".join(args))
   for line in captured.splitlines():
     log.info(config + ": " + line)
+  log.info('')
+  log.info('')
+
 
   globallock.release()
 

--- a/plugins/set/set.yapsy-plugin
+++ b/plugins/set/set.yapsy-plugin
@@ -1,0 +1,9 @@
+[Core]
+Name = set
+Module = set
+
+[Documentation]
+Author = Stephan Huber
+Version = 0.1
+Website = http://www.factorial.io
+Description = Set Plugin

--- a/plugins/variants/variants.py
+++ b/plugins/variants/variants.py
@@ -28,6 +28,8 @@ def runFabalicious(args):
       output = process.stdout.readline().decode()
       if output:
         captured += output
+
+        # Log every line as debug, so the user can check, if everything is running well.
         log.debug(config + ": " + output.replace("\n", ""))
       else:
         break
@@ -49,7 +51,7 @@ def runFabalicious(args):
   globallock.release()
 
 
-class Set(ITaskPlugin):
+class VariantsTask(ITaskPlugin):
   def run(self, *args, **kwargs):
     num_processes = int(kwargs['processes']) if 'processes' in kwargs else 1
 
@@ -60,7 +62,7 @@ class Set(ITaskPlugin):
     blueprints = configuration.getSettings('blueprints')
     config = configuration.current()
     if not config:
-      log.error('set needs a valid configuration!')
+      log.error('variants needs a valid configuration!')
       exit(1)
 
     config_name = configuration.current('config_name')
@@ -97,6 +99,7 @@ class Set(ITaskPlugin):
       commands.append(command)
 
       log.info(" ".join(command))
+
     log.info("Using %s parallel processes" % num_processes)
     result = raw_input('Do you want to execute above listed commands? (Y/N) ')
 
@@ -106,5 +109,6 @@ class Set(ITaskPlugin):
     with poolcontext(processes=num_processes) as pool:
       pool.map(runFabalicious, commands)
 
+    # stop processing dangling tasks.
     exit(0)
 

--- a/plugins/variants/variants.yapsy-plugin
+++ b/plugins/variants/variants.yapsy-plugin
@@ -1,9 +1,9 @@
 [Core]
-Name = set
-Module = set
+Name = variants
+Module = variants
 
 [Documentation]
 Author = Stephan Huber
 Version = 0.1
 Website = http://www.factorial.io
-Description = Set Plugin
+Description = Variants Plugin


### PR DESCRIPTION
Hi @d34dman 

please have a look at the `variants`-plugin. It will introduce a new task called `variants` which allows the parallel execution of one or more fab-tasks on multiple instances via blueprints.

### Prerequisites
* The fabfile needs a blueprints-section listing all possible variants for a given configuration.
* It's currently implemented as a plugin so yapsi needs to be installed

### Examples

to reset all multisites on `mbb`

```
fab config:mbb variants:all reset
```

you can even run the processes in parallel, just run

```
fab config:mbb variants:all,processes=4 reset
```

or a subset of blueprint variants:

```
fab config:mbb variants:cardiocity,oncocity reset
```

I keep it as WIP as it needs some more testing, fixes #64 